### PR TITLE
Fixed missing step for adding tags

### DIFF
--- a/doc_source/rs-gsg-create-an-iam-role.md
+++ b/doc_source/rs-gsg-create-an-iam-role.md
@@ -18,7 +18,9 @@ In this step, you create a new IAM role that enables Amazon Redshift to load dat
 
 1. Under **Select your use case**, choose **Redshift \- Customizable** then choose **Next: Permissions**\.
 
-1. On the **Attach permissions policies** page, choose **AmazonS3ReadOnlyAccess**, and then choose **Next: Review**\.
+1. On the **Attach permissions policies** page, choose **AmazonS3ReadOnlyAccess**, and then choose **Next: Tags**\.
+
+1. Tags are optional, we will be skipping this. Choose **Next: Review**\.
 
 1. For **Role name**, type a name for your role\. For this tutorial, type `myRedshiftRole`\. 
 


### PR DESCRIPTION
After setting permissions, the next step is Tags. Since this tutorial does not use tags, this change would advise the student to skip tags for this example.
